### PR TITLE
Move FROM statement to top of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-MAINTAINER Italo Valcy <italovalcy@gmail.com>
-
 FROM kytos/nightly
+MAINTAINER Italo Valcy <italovalcy@gmail.com>
 
 RUN for napp in storehouse of_core flow_manager topology of_lldp pathfinder mef_eline maintenance; do git clone https://github.com/kytos/$napp;  cd $napp; python3.6 setup.py develop || true; cd ..; done
 


### PR DESCRIPTION
This fixes #1 

After doing some research, I discovered that the FROM statement has to precede other statements in a Dockerfile. Moving it to the top and re-running `docker-compose up -d` caused no errors.